### PR TITLE
Make image server configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <sinai.port>8443</sinai.port>
     <sinai.redirect.port>8000</sinai.redirect.port>
     <sinai.jks>sinai.jks</sinai.jks>
+    <sinai.image.server>https://stage-images.library.ucla.edu</sinai.image.server>
     <!-- These are samples for testing purposes only ... DO NOT USE THEM IN PRODUCTION!!! -->
     <sinai.json.config.path>${basedir}/src/main/resources/sample-config.json</sinai.json.config.path>
     <dev.tools></dev.tools>

--- a/src/main/java/edu/ucla/library/sinai/handlers/SinaiHandler.java
+++ b/src/main/java/edu/ucla/library/sinai/handlers/SinaiHandler.java
@@ -37,6 +37,8 @@ abstract class SinaiHandler implements Handler<RoutingContext> {
      * @return A Handlebars context that can be passed to the template engine
      */
     Context toHbsContext(final ObjectNode aJsonObject, final RoutingContext aContext) {
+        aJsonObject.put("imageserver", System.getProperty("sinai.image.server"));
+
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("{} JSON passed to template page: {}", getClass().getSimpleName(), aJsonObject.toString());
         }

--- a/src/main/scripts/startup.sh
+++ b/src/main/scripts/startup.sh
@@ -4,7 +4,8 @@
 LOG_DELEGATE="-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory"
 KEY_PASS_CONFIG="-Dsinai.key.pass=${sinai.key.pass}"
 SINAI_TEMP_DIR="-Dsinai.temp.dir=${sinai.temp.dir}"
-SINAI_PORT="-Dsinai.port=${sinai.port}"
+SINAI_PORT="-Dsinai.port=${sinai.port} -Dsinai.redirect.port=${sinai.redirect.port}"
+IMAGE_SERVER="-Dsinai.image.server=${sinai.image.server}"
 DROPWIZARD_METRICS="-Dvertx.metrics.options.enabled=true -Dvertx.metrics.options.registryName=sinai.metrics"
 JMX_METRICS="-Dcom.sun.management.jmxremote -Dvertx.metrics.options.jmxEnabled=true"
 # For tools like Eclipse's Debugging
@@ -36,5 +37,5 @@ if [[ "${dev.tools}" == *"JMX_REMOTE"* ]]; then
   JMX_METRICS="$JMX_METRICS $JMX_REMOTE"
 fi
 
-$AUTHBIND java $LOG_DELEGATE $KEY_PASS_CONFIG $SINAI_TEMP_DIR $SINAI_PORT $DROPWIZARD_METRICS \
+$AUTHBIND java $IMAGE_SERVER $LOG_DELEGATE $KEY_PASS_CONFIG $SINAI_TEMP_DIR $SINAI_PORT $DROPWIZARD_METRICS \
   $JMX_METRICS $1 -jar target/sinai-web-${project.version}-exec.jar $SINAI_CONFIG

--- a/src/main/webapp/templates/browse.hbs
+++ b/src/main/webapp/templates/browse.hbs
@@ -25,7 +25,7 @@
 					<ul>
 						<li>
 								<span class="helper"></span>
-								<img class='browse-thumbnail' src="https://stage-images.library.ucla.edu/iiif/ark:%2F21198%2Fz14q7rws/0,1022,6132,6132/150,150/0/default.jpg" alt="AraN8">
+								<img class='browse-thumbnail' src="{{imageserver}}/iiif/ark:%2F21198%2Fz14q7rws/0,1022,6132,6132/150,150/0/default.jpg" alt="AraN8">
 								<p>
 								<a href="/view/ark%3A%2F21198%2Fz1kd1z25">Arabic NF 8</a> 
                                 <a class="beta" href="/viewer2/ark:%2F21198%2Fz14q7rws?selected=ark%3A%2F21198%2Fz1kd1z25/AraNF-8_001r_61-001"><img src="http://www.optrip.com/images/logo/optrip-beta.png" alt="beta">FLEXIBLE WORKSPACE VIEWER</a><br><br>
@@ -37,7 +37,7 @@
 						</li>
 						<li>
 								<span class="helper"></span>
-								<img class='browse-thumbnail' src="https://stage-images.library.ucla.edu/iiif/ark:%2F21198%2Fz1np24m5/0,902,5412,5412/150,150/0/default.jpg" alt="Syr2A">
+								<img class='browse-thumbnail' src="{{imageserver}}/iiif/ark:%2F21198%2Fz1np24m5/0,902,5412,5412/150,150/0/default.jpg" alt="Syr2A">
 								<p>
 								<a href="/view/ark%3A%2F21198%2Fz1h70g33">Syriac 2A</a> 
                                 <a class="beta" href="/viewer2/ark:%2F21198%2Fz1np24m5?selected=ark%3A%2F21198%2Fz1h70g33/Syr-2A_123r_13-001"><img src="http://www.optrip.com/images/logo/optrip-beta.png" alt="beta">FLEXIBLE WORKSPACE VIEWER</a><br><br>

--- a/src/main/webapp/templates/scan.hbs
+++ b/src/main/webapp/templates/scan.hbs
@@ -27,7 +27,7 @@
             });
           };
 
-          $.getJSON('https://stage-images.library.ucla.edu/iiif/{{id}}/manifest/thumbnails', load);
+          $.getJSON('{{imageserver}}/iiif/{{id}}/manifest/thumbnails', load);
         });
       })(jQuery);
     </script>

--- a/src/main/webapp/templates/view.hbs
+++ b/src/main/webapp/templates/view.hbs
@@ -57,7 +57,7 @@
           }
         };
 
-        $.getJSON('https://stage-images.library.ucla.edu/iiif/{{id}}/manifest/thumbnails', setup);
+        $.getJSON('{{imageserver}}/iiif/{{id}}/manifest/thumbnails', setup);
       });
     </script>
   </head>

--- a/src/main/webapp/templates/viewer.hbs
+++ b/src/main/webapp/templates/viewer.hbs
@@ -36,14 +36,14 @@
           "showAddFromURLBox": false,
           "layout": "1x2",
           "data": [{
-            "manifestUri": "https://stage-images.library.ucla.edu/iiif/{{id}}/manifest",
+            "manifestUri": "{{imageserver}}/iiif/{{id}}/manifest",
             "location": "UCLA"
           },{
-            "manifestUri": "https://stage-images.library.ucla.edu/iiif/{{selected}}/manifest",
+            "manifestUri": "{{imageserver}}/iiif/{{selected}}/manifest",
             "location": "UCLA"
           }],
           "windowObjects": [{
-            "loadedManifest": "https://stage-images.library.ucla.edu/iiif/{{id}}/manifest",
+            "loadedManifest": "{{imageserver}}/iiif/{{id}}/manifest",
             "slotAddress" : "row1.column1",
             "availableViews": ["ImageView"],
             "viewType": "ImageView",
@@ -60,7 +60,7 @@
             "sidePanel": false,
             "sidePanelVisible": false
           },{
-            "loadedManifest": "https://stage-images.library.ucla.edu/iiif/{{selected}}/manifest",
+            "loadedManifest": "{{imageserver}}/iiif/{{selected}}/manifest",
             "slotAddress" : "row1.column2",
             "availableViews": ["ImageView", "ThumbnailsView", "BookView"],
             "viewType": "ImageView",

--- a/src/main/webapp/templates/viewer2.hbs
+++ b/src/main/webapp/templates/viewer2.hbs
@@ -23,14 +23,14 @@
           "showAddFromURLBox": false,
           "layout": "1x2",
           "data": [{
-            "manifestUri": "https://stage-images.library.ucla.edu/iiif/{{id}}/manifest",
+            "manifestUri": "{{imageserver}}/iiif/{{id}}/manifest",
             "location": "UCLA"
           },{
-            "manifestUri": "https://stage-images.library.ucla.edu/iiif/{{selected}}/manifest",
+            "manifestUri": "{{imageserver}}/iiif/{{selected}}/manifest",
             "location": "UCLA"
           }],
           "windowObjects": [{
-            "loadedManifest": "https://stage-images.library.ucla.edu/iiif/{{id}}/manifest",
+            "loadedManifest": "{{imageserver}}/iiif/{{id}}/manifest",
             "slotAddress" : "row1.column1",
             "availableViews": ["ImageView"],
             "viewType": "ImageView",
@@ -47,7 +47,7 @@
             "sidePanel": false,
             "sidePanelVisible": false
           },{
-            "loadedManifest": "https://stage-images.library.ucla.edu/iiif/{{selected}}/manifest",
+            "loadedManifest": "{{imageserver}}/iiif/{{selected}}/manifest",
             "slotAddress" : "row1.column2",
             "availableViews": ["ImageView", "ThumbnailsView", "BookView"],
             "viewType": "ImageView",


### PR DESCRIPTION
These changes allow the image server to be configured at build so that the sinai-web application and the image server can be run on the same machine (of course your local image server needs to have the files that the sinai-web application expects or you'll get broken links).

To build the sinai-web application so that it works with a local image server, you'd type:

    mvn clean install -Dsinai.port=8444 -Dsinai.redirect.port=8001 -Dsinai.image.server="https://localhost:8443"

The port needs to be 8444 because that's what's been configured in the Google OAuth configuration. Port 8001 hasn't been configured in Google OAuth but it needs to be different from the redirect port of the image server or you'll have a port conflict. It's not expected that a dev would be using the redirect port.