### PR TITLE
Fix imageserver links

### DIFF
--- a/src/main/java/edu/ucla/library/sinai/RoutePatterns.java
+++ b/src/main/java/edu/ucla/library/sinai/RoutePatterns.java
@@ -34,6 +34,11 @@ public interface RoutePatterns {
     public static final String LOGOUT = "/logout";
 
     /**
+     * A path for the browse page.
+     */
+    public static final String BROWSE = "/browse";
+
+    /**
      * A generic path for Web application metrics.
      */
     public static final String STATUS = "/status/*";

--- a/src/main/java/edu/ucla/library/sinai/handlers/PageHandler.java
+++ b/src/main/java/edu/ucla/library/sinai/handlers/PageHandler.java
@@ -1,0 +1,34 @@
+
+package edu.ucla.library.sinai.handlers;
+
+import static edu.ucla.library.sinai.Constants.HBS_DATA_KEY;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import edu.ucla.library.sinai.Configuration;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * A generic page handler.
+ */
+public class PageHandler extends SinaiHandler {
+
+    public PageHandler(final Configuration aConfig) {
+        super(aConfig);
+    }
+
+    /**
+     * The basic handle method for a Handler<RoutingContext>.
+     */
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final ObjectMapper mapper = new ObjectMapper();
+        final ObjectNode jsonNode = mapper.createObjectNode();
+
+        // We're not adding specific here yet but we do need what's set in SinaiHandler
+        aContext.data().put(HBS_DATA_KEY, toHbsContext(jsonNode, aContext));
+        aContext.next();
+    }
+
+}

--- a/src/main/java/edu/ucla/library/sinai/verticles/SinaiMainVerticle.java
+++ b/src/main/java/edu/ucla/library/sinai/verticles/SinaiMainVerticle.java
@@ -23,6 +23,7 @@ import edu.ucla.library.sinai.handlers.LoginHandler;
 import edu.ucla.library.sinai.handlers.LogoutHandler;
 import edu.ucla.library.sinai.handlers.MetricsHandler;
 import edu.ucla.library.sinai.handlers.MiradorHandler;
+import edu.ucla.library.sinai.handlers.PageHandler;
 import edu.ucla.library.sinai.handlers.SearchHandler;
 import edu.ucla.library.sinai.handlers.StatusHandler;
 import edu.ucla.library.sinai.templates.HandlebarsTemplateEngine;
@@ -138,7 +139,10 @@ public class SinaiMainVerticle extends AbstractSinaiVerticle implements RoutePat
         // Then we have the plain old administrative UI patterns
         router.getWithRegex(METRICS_RE).handler(new MetricsHandler(myConfig));
 
-        // Create a index handler just to test for session; this could go in template handler
+        // We just use the generic handler for browse page
+        router.get(BROWSE).handler(new PageHandler(myConfig));
+
+        // Create a catch-all that passes content to the template handler
         router.get().handler(templateHandler).failureHandler(failureHandler);
 
         // Configure our StatusHandler, used by the Nagios script

--- a/src/main/resources/supervisord.conf
+++ b/src/main/resources/supervisord.conf
@@ -25,6 +25,7 @@ command=authbind java
     "-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory"
     "-Dsinai.key.pass=${sinai.key.pass}" "-Dsinai.temp.dir=${sinai.temp.dir}" "-Dsinai.port=443"
     "-Dsinai.redirect.port=80" "-Dsinai.host=${sinai.host}" "-Dsinai.solr.server=${sinai.solr.server}"
-    "-Dvertx.metrics.options.enabled=true" "-Dvertx.metrics.options.registryName=sinai.metrics" "-Dsinai.jks=${sinai.jks}"
+    "-Dvertx.metrics.options.enabled=true" "-Dvertx.metrics.options.registryName=sinai.metrics"
+    "-Dsinai.jks=${sinai.jks}" "-Dsinai.image.server=${sinai.image.server}"
     "-Dcom.sun.management.jmxremote" "-Dvertx.options.jmxEnabled=true" "-Djdk.tls.ephemeralDHKeySize=2048"
     -jar ${sinai.deployment.dir}/sinai-web-${project.version}-exec.jar -conf "${sinai.json.config.path}"


### PR DESCRIPTION
The browse page hadn't previously had a variables in it so it wasn't using a handler that extended SinaiHandler (it was just using the generic template handler). Adding the {{imageserver}} variable to the page meant we needed a handler that extended SinaiHandler so that the variable would be included in the information that was passed along to the TemplateHandler (so it could then show up on the page). I created a generic PageHandler and configured the /browse route to be handled by it. I also added the variable to the supervisord.conf.