### PR TITLE
Metadata updater

### DIFF
--- a/src/main/java/edu/ucla/library/sinai/handlers/FailureHandler.java
+++ b/src/main/java/edu/ucla/library/sinai/handlers/FailureHandler.java
@@ -6,9 +6,10 @@ import static edu.ucla.library.sinai.Constants.MESSAGES;
 
 import java.io.IOException;
 
-import edu.ucla.library.sinai.Configuration;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.sinai.Configuration;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -89,7 +90,7 @@ public class FailureHandler extends SinaiHandler {
             if (throwable != null) {
                 String message = throwable.getMessage();
 
-                if (message.startsWith("/webroot/templates")) {
+                if (message != null && message.startsWith("/webroot/templates")) {
                     jsonObject.put(ERROR_HEADER, "File Not Found");
                     message = message.replace("/webroot/templates", "").replace(".hbs", "");
                 } else if (errorMessage != null) {
@@ -116,7 +117,7 @@ public class FailureHandler extends SinaiHandler {
                 }
             });
 
-        } catch (IOException e) {
+        } catch (final IOException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }

--- a/src/main/java/edu/ucla/library/sinai/templates/impl/HandlebarsTemplateEngineImpl.java
+++ b/src/main/java/edu/ucla/library/sinai/templates/impl/HandlebarsTemplateEngineImpl.java
@@ -21,6 +21,7 @@ import static edu.ucla.library.sinai.Constants.HBS_PATH_SKIP_KEY;
 import static edu.ucla.library.sinai.Constants.MESSAGES;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -58,9 +59,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.templ.impl.CachingTemplateEngine;
 
 /**
- * @author <a href="http://pmlopes@gmail.com">Paulo Lopes</a>
- * @author <a href="http://tfox.org">Tim Fox</a>
- * @author <a href="mailto:ksclarke@library.ucla.edu">Kevin S. Clarke</a>
+ * The Handlebars template engine. This takes JSON and passes it to the Handlebars transformer to generate HTML pages.
  */
 public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template> implements
         HandlebarsTemplateEngine {
@@ -1181,6 +1180,9 @@ public class HandlebarsTemplateEngineImpl extends CachingTemplateEngine<Template
             }
 
             aHandler.handle(Future.succeededFuture(Buffer.buffer(templateOutput)));
+        } catch (final FileNotFoundException details) {
+            LOGGER.debug(details.getMessage(), details);
+            aHandler.handle(Future.failedFuture(details));
         } catch (final Exception details) {
             LOGGER.error(details, details.getMessage());
             aHandler.handle(Future.failedFuture(details));

--- a/src/main/java/edu/ucla/library/sinai/verticles/SinaiMainVerticle.java
+++ b/src/main/java/edu/ucla/library/sinai/verticles/SinaiMainVerticle.java
@@ -230,7 +230,7 @@ public class SinaiMainVerticle extends AbstractSinaiVerticle implements RoutePat
             future.setHandler(aHandler);
 
             futures.add(deployVerticle(SolrServiceVerticle.class.getName(), options, Future.future()));
-            futures.add(deployVerticle(MetadataHarvestVerticle.class.getName(), options, Future.future()));
+            // futures.add(deployVerticle(MetadataHarvestVerticle.class.getName(), options, Future.future()));
 
             // Confirm all our verticles were successfully deployed
             CompositeFuture.all(futures).setHandler(handler -> {


### PR DESCRIPTION
The main purpose of this commit is to turn off the metadata updater to confirm that it's what's causing the non-responsiveness problems. A few other cleanup things were done too though:

* Turned off the metadata updater
* Fix NullPointerException that sometimes gets thrown if there is no message in an exception
* Turn down logging level of a template not found -- it's not an ERROR but a DEBUG opportunity