### PR TITLE
Update Travis JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 env:
   global:


### PR DESCRIPTION
OracleJDK has periodic issues with Travis now due to Oracle's licensing. Just use OpenJDK instead.