### PR TITLE
[SERV-105] Add comments to clarify authentication flow

### DIFF
--- a/src/main/java/edu/ucla/library/sinai/handlers/LoginHandler.java
+++ b/src/main/java/edu/ucla/library/sinai/handlers/LoginHandler.java
@@ -11,6 +11,7 @@ import edu.ucla.library.sinai.RoutePatterns;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.jwt.JWTOptions;
 import io.vertx.ext.web.Cookie;
@@ -27,27 +28,49 @@ public class LoginHandler extends SinaiHandler {
         myJwtAuth = aJwtAuth;
     }
 
+    /**
+     * Handles the authentication callback request from <sinai-id.org>.
+     *
+     * The authentication flow for this application doesn't correspond to any of Vert.x's built-in AuthProviders.
+     * Instead, we authenticate a user by trusting a callback HTTP request originating from <sinai-id.org>.
+     *
+     * Essentially, we check that the token provided in that request matches the token that we've placed in a cookie in
+     * the user's browser. That cookie is created or updated whenever <code>src/main/webapp/templates/header.hbs</code>
+     * is rendered while the user is not logged in, and is used solely for the initial authentication request.
+     *
+     * @param aContext A routing context
+     */
     @Override
     public void handle(final RoutingContext aContext) {
         final MultiMap params = aContext.request().params();
+        final HttpServerResponse response = aContext.response();
 
         if (params.contains(TOKEN)) {
             final String rawToken = params.get(TOKEN);
-            final JWTOptions jwtOptions = new JWTOptions().setExpiresInSeconds(60);
-            final String token = myJwtAuth.generateToken(new JsonObject().put("sub", "asdf"), jwtOptions);
             final Cookie cookie = aContext.getCookie(TOKEN);
 
-            // Not perfect, we know, but a good faith effort
             if (cookie != null && rawToken != null && rawToken.equals(cookie.getValue())) {
-                myJwtAuth.authenticate(new JsonObject().put("jwt", token), authHandler -> {
-                    final HttpServerResponse response = aContext.response();
+                // At this point, we can trust that the sinai-id service has authenticated the user.
+                //
+                // Since the authentication flow for this application doesn't correspond to any of Vert.x's built-in
+                // AuthProviders, the following JWT transaction is essentially a no-op that we perform for one reason
+                // only: putting a User on the RoutingContext. We never actually send the token to the client, so each
+                // call to this handler generates the same token.
+                final JWTOptions jwtOptions = new JWTOptions().setExpiresInSeconds(60);
+                final String token = myJwtAuth.generateToken(new JsonObject().put("sub", "asdf"), jwtOptions); // whatevs
 
+                // We now authenticate the useless token so that we can obtain a reference to a User object via the
+                // AuthProvider API.
+                myJwtAuth.authenticate(new JsonObject().put("jwt", token), authHandler -> {
                     if (authHandler.succeeded()) {
+                        final User user = authHandler.result();
+
+                        // This starts the user's session, which is tracked by a Vert.x-managed session cookie
+                        aContext.setUser(user);
+
                         if (LOGGER.isDebugEnabled()) {
                             LOGGER.debug("User successfully validated");
                         }
-
-                        aContext.setUser(authHandler.result());
                         aContext.reroute(RoutePatterns.SEARCH_RESULTS_RE);
                     } else {
                         LOGGER.error(authHandler.cause(), "Authentication did not succeed");
@@ -58,7 +81,7 @@ public class LoginHandler extends SinaiHandler {
             } else {
                 final String message = "Tried to authenticate, but the tokens didn't match";
                 LOGGER.error(message);
-                aContext.response().putHeader(Metadata.CONTENT_TYPE, Metadata.TEXT_MIME_TYPE).end(message);
+                response.putHeader(Metadata.CONTENT_TYPE, Metadata.TEXT_MIME_TYPE).end(message);
             }
         } else {
             try {

--- a/src/main/webapp/templates/header.hbs
+++ b/src/main/webapp/templates/header.hbs
@@ -38,16 +38,18 @@
     });
   }
 
-  var uuid = uuidv4();
-
-  $('#token').val(uuid);
-  document.cookie = "token=" + uuid;
-</script>
-
-<script>
   {{#if logged-in}}
     $("#loginLink").remove();
   {{else}}
+    var uuid = uuidv4();
+
+    // If the user is not logged in, create a cookie, containing a token, that will only be used for the initial
+    // authentication request to sinai-id. Once a user is logged in, they will receive a separate session cookie
+    // provided by Vert.x.
+
+    $('#token').val(uuid);
+    document.cookie = "token=" + uuid;
+
     $("#logoutLink").remove();
   {{/if}}
 </script>


### PR DESCRIPTION
Changes:

- ~shorten the user session timeout to three days~
- only update the "initial-auth-token" cookie (`header.hbs`) if a user isn't logged in, since it's never used while a user is logged in
- add comments explaining the no-op nature of the JWT auth flow
- ~add comment explaining the reason for the session timeout after three days~
- change scope of a few variables in LoginHandler

I have not yet tested this change due to some difficulty spinning up the application locally, but I intend to do so before merging.

Edit: reverted session timeout value