### PR TITLE
[SERV-249] Upload build artifact with correct S3 prefix

### DIFF
--- a/.github/workflows/build-artifact-upload.yml
+++ b/.github/workflows/build-artifact-upload.yml
@@ -52,4 +52,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-west-2
           SOURCE_DIR: ./target/build-artifact
-          DEST_DIR: /sinai-web/master
+          DEST_DIR: sinai-web/master


### PR DESCRIPTION
The JAR upload succeeded but it got the wrong prefix, this should fix that