### PR TITLE
[SERV-361] Accommodate move to Solr 8

### DIFF
--- a/src/main/java/edu/ucla/library/sinai/verticles/MetadataHarvestVerticle.java
+++ b/src/main/java/edu/ucla/library/sinai/verticles/MetadataHarvestVerticle.java
@@ -195,10 +195,11 @@ public class MetadataHarvestVerticle extends AbstractSinaiVerticle {
                             throw new Error(errorMessage);
                         }
 
-                        solrFieldName = fields[i].name + solrDynamicFieldSuffix(fields[i].type, fields[i].multiValued);
-                        if (fields[i].name.equals("uuid")) {
+                        if (fields[i].name.equals("id")) {
+                            solrFieldName = fields[i].name;
                             doc.addField(solrFieldName, solrFieldValue);
                         } else {
+                            solrFieldName = fields[i].name + solrDynamicFieldSuffix(fields[i].type, fields[i].multiValued);
                             // http://yonik.com/solr/atomic-updates/
                             solrInputField = new HashMap<String, Object>(1);
                             solrInputField.put("set", solrFieldValue);
@@ -232,7 +233,7 @@ public class MetadataHarvestVerticle extends AbstractSinaiVerticle {
                 final String multiValuedFieldDelimiter = ",";
 
                 final MetadataHarvestDBFields[] manuscriptsFields = {
-                    new MetadataHarvestDBFields("uuid", "m.uuid", "string", false),
+                    new MetadataHarvestDBFields("id", "m.uuid", "string", false),
                     new MetadataHarvestDBFields("manuscript_id", "m.id", "int", false),
                     new MetadataHarvestDBFields("shelf_mark", "m.shelf_mark", "string", false),
                     new MetadataHarvestDBFields("title", "m.title", "string", false),
@@ -271,7 +272,7 @@ public class MetadataHarvestVerticle extends AbstractSinaiVerticle {
 
                 // Add UTOs
                 final MetadataHarvestDBFields[] utoFields = {
-                    new MetadataHarvestDBFields("uuid", "uto.uuid", "string", false),
+                    new MetadataHarvestDBFields("id", "uto.uuid", "string", false),
                     new MetadataHarvestDBFields("undertext_object_id", "uto.id", "int", false),
                     new MetadataHarvestDBFields("manuscript_id", "tlg.manuscript_id", "int", false),
                     new MetadataHarvestDBFields("shelf_mark", "m.shelf_mark", "string", false),
@@ -302,7 +303,7 @@ public class MetadataHarvestVerticle extends AbstractSinaiVerticle {
 
                 // Add folios (manuscript components)
                 final MetadataHarvestDBFields[] folioFields = {
-                    new MetadataHarvestDBFields("uuid", "mc.uuid", "string", false),
+                    new MetadataHarvestDBFields("id", "mc.uuid", "string", false),
                     new MetadataHarvestDBFields("manuscript_id", "mc.manuscript_id", "int", false),
                     new MetadataHarvestDBFields("manuscript_component_id", "mc.id", "int", false),
 
@@ -345,7 +346,7 @@ public class MetadataHarvestVerticle extends AbstractSinaiVerticle {
 
                 // Add under text layers
                 final MetadataHarvestDBFields[] underTextLayerFields = {
-                    new MetadataHarvestDBFields("uuid", "tl.uuid", "string", false),
+                    new MetadataHarvestDBFields("id", "tl.uuid", "string", false),
                     new MetadataHarvestDBFields("manuscript_id", "mc.manuscript_id", "int", false),
                     new MetadataHarvestDBFields("undertext_object_id", "tl.undertext_object_id", "int", false),
                     new MetadataHarvestDBFields("manuscript_component_id", "tl.manuscript_component_id", "int", false),
@@ -375,7 +376,7 @@ public class MetadataHarvestVerticle extends AbstractSinaiVerticle {
 
                 // Add over text layers
                 final MetadataHarvestDBFields[] overTextLayerFields = {
-                    new MetadataHarvestDBFields("uuid", "tl.uuid", "string", false),
+                    new MetadataHarvestDBFields("id", "tl.uuid", "string", false),
                     new MetadataHarvestDBFields("manuscript_id", "mc.manuscript_id", "int", false),
                     new MetadataHarvestDBFields("manuscript_component_id", "tl.manuscript_component_id", "int", false),
                     new MetadataHarvestDBFields("text_identity", "tl.text_identity", "string", false),

--- a/src/main/scripts/configureSolrSchema.sh
+++ b/src/main/scripts/configureSolrSchema.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Uses the Solr schema API to configure the core for the Sinai Scholars Site.
+# This script assumes Solr version 8.11. See https://solr.apache.org/guide/8_11/schema-api.html for the schema API docs.
+
+usage() {
+    echo "Usage: $0 SOLR_CORE_URL"
+}
+
+if [ -z $1 ]
+then
+    usage
+    exit 1
+fi
+
+curl -X POST -H 'Content-type: application/json' "$1/schema" --data-binary '{
+    "add-field": [
+        { "name": "keyword_t", "type": "text_general", "indexed": true, "stored": true },
+        { "name": "record_type_s", "type": "string", "indexed": true, "stored": true, "required": true } ],
+    "add-copy-field": [
+        { "source": "*_s", "dest": [ "keyword_t" ] },
+        { "source": "*_i", "dest": [ "keyword_t" ] } ]
+}'


### PR DESCRIPTION
The script uses the schema API to configure the Solr core schema. Because that API does not allow changing the `uniqueKey` field to something other than `id`, the code uses `id` now too.