### PR TITLE
Fix typo in PDFProxyHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ sinai-*.log
 
 # A custom Logback configuration
 logback.xml
+
+# A build artifact that's recreated each time
+.flattened-pom.xml

--- a/src/main/java/edu/ucla/library/sinai/handlers/PDFProxyHandler.java
+++ b/src/main/java/edu/ucla/library/sinai/handlers/PDFProxyHandler.java
@@ -20,7 +20,7 @@ public class PDFProxyHandler extends SinaiHandler {
     public void handle(final RoutingContext aContext) {
         switch (aContext.normalisedPath()) {
         case "/terms-of-use/please-read":
-            aContext.reroute("/pdfs/A-1-Terms-of-Use_20231129.pdf");
+            aContext.reroute("/pdfs/A-1_Terms-of-Use_20231129.pdf");
             break;
         case "/terms-of-use/contributors":
             aContext.reroute("/pdfs/A-2_Citing-Contributors_20231129.pdf");


### PR DESCRIPTION
Missed a typo in the PDF redirection that caused a broken link. Fixed that, and added a new entry to the .gitignore.